### PR TITLE
Change -> to unicode arrow

### DIFF
--- a/lua/autorun/server/sv_chat_visibility.lua
+++ b/lua/autorun/server/sv_chat_visibility.lua
@@ -63,7 +63,7 @@ hook.Add( "ULibPostTranslatedCommand", "CFC_ChatVisibility_ULibCommand", functio
         recipient = recipient,
         message = {
             teamColor( author ), author:GetName(),
-            colors.psay_seperator, " -> ",
+            colors.psay_seperator, " → ",
             teamColor( recipient ), recipient:GetName(),
             colors.text, ": ", text
         },

--- a/lua/autorun/server/sv_chat_visibility.lua
+++ b/lua/autorun/server/sv_chat_visibility.lua
@@ -63,7 +63,7 @@ hook.Add( "ULibPostTranslatedCommand", "CFC_ChatVisibility_ULibCommand", functio
         recipient = recipient,
         message = {
             teamColor( author ), author:GetName(),
-            colors.psay_seperator, " → ",
+            colors.psay_seperator, " ➔ ",
             teamColor( recipient ), recipient:GetName(),
             colors.text, ": ", text
         },


### PR DESCRIPTION
Replaces the arrow with an actual unicode arrow symbol so it displays better in chat.